### PR TITLE
Fix passing of bam

### DIFF
--- a/mro/_snp_clusterer_stages.mro
+++ b/mro/_snp_clusterer_stages.mro
@@ -12,6 +12,9 @@ stage MODIFY_BAM(
     in  path   reference_path,
     out bam    second_bam,
     src py     "stages/snpclust/modify_bam",
+) using (
+    threads = 8,
+    mem_gb = 6,
 )
 
 stage FILTER_READS(
@@ -32,8 +35,12 @@ stage CALL_SNPS(
     in  path   bed_file,
     out vcf[]  output,
     src py     "stages/snpclust/call_snps",
-) split using (
+) split (
     in  string locus,
+)
+ using (
+    mem_gb = 32,
+    threads = 8,
 )
 
 stage COUNT_ALLELES(

--- a/mro/stages/snpclust/filter_reads/__init__.py
+++ b/mro/stages/snpclust/filter_reads/__init__.py
@@ -9,7 +9,7 @@ import cellranger.utils as cr_utils
 
 __MRO__ = '''
 stage FILTER_READS(
-    in  bam    second_bam,
+    in  bam    input,
     in  tsv    cell_barcodes,
     in  map    align,
     out bam    output,
@@ -21,7 +21,7 @@ stage FILTER_READS(
 '''
 
 def split(args):
-    with tk_bam.create_bam_infile(args.second_bam) as in_bam:
+    with tk_bam.create_bam_infile(args.input) as in_bam:
         chunks = tk_bam.chunk_bam_records(in_bam, chunk_bound_key=cr_utils.pos_sort_key,
                                           chunk_size_gb=cr_constants.BAM_CHUNK_SIZE_GB,
                                           max_chunks=cr_constants.MAX_BAM_CHUNKS)


### PR DESCRIPTION
Here is the fix. Also some stuff for the thread management that you will need to run on hydra. Still not sure how to restrict the core usage of GATK. Looking at the longranger code base, they run GATK directly from the .jar file instead of this `gatk-launch` script you have.